### PR TITLE
Add schema.org Article markup to c4lj theme

### DIFF
--- a/single.php
+++ b/single.php
@@ -1,9 +1,9 @@
 <?php get_header(); ?>
 <?php get_sidebar(); ?>
 
-			<div id="content">
+			<div id="content" vocab="http://schema.org/">
 				<?php if (have_posts()) : while (have_posts()) : the_post(); ?>
-				<div class="article" id="post-<?php the_ID(); ?>">
+				<div class="article" id="post-<?php the_ID(); ?>" typeof="Article">
 					<p id="issueDesignation"><?php foreach( (get_the_category()) as $cat ) {
               $parent = get_category($cat->category_parent);
 							if ( $parent && $parent->category_nicename == "issues" ) { // category should be child of Issues
@@ -11,14 +11,15 @@
 								break; // only do this once. Something's wrong if it's in multiple issues
 							}
 						}?></p>
-					<h1 class="articletitle"><?php the_title(); ?></h1>
-					<div class="abstract">
+					<h1 class="articletitle" property="name"><?php the_title(); ?></h1>
+					<p class="author"><?php the_author(); ?></p>
+					<div class="abstract" property="description">
 						<?php the_excerpt(); ?>
 					</div>
-					<div class="entry">
+					<div class="entry" property="articleBody">
 						<?php the_content('<p class="readmore">Read this article...</p>'); ?>
 					</div>
-					<?php the_tags( '<p class="tags">Tags: ', ', ', '</p>'); ?>
+					<?php the_tags( '<p class="tags" property="keywords">Tags: ', ', ', '</p>'); ?>
 					<?php edit_post_link('Edit this article', '<p class="editlink">', '</p>'); ?>
 				</div>
 				<?php comments_template(); ?>


### PR DESCRIPTION
We won't get author markup if we're not using the Co-Authors-Plus
plugin, but otherwise things should be good for the basics of the
article title, abstract, and article body for each journal article.

Signed-off-by: Dan Scott dan@coffeecode.net
